### PR TITLE
Swap h for H to toggle HTML in mu4e-view mode

### DIFF
--- a/evil-mu4e.el
+++ b/evil-mu4e.el
@@ -92,7 +92,7 @@
                                                           (interactive)
                                                           (mu4e-headers-mark-thread nil '(read))))
 
-    (,evil-mu4e-state mu4e-view-mode-map "h"               mu4e-view-toggle-html)
+    (,evil-mu4e-state mu4e-view-mode-map "H"               mu4e-view-toggle-html)
     (,evil-mu4e-state mu4e-view-mode-map "e"               mu4e-view-save-attachment)
     (,evil-mu4e-state mu4e-view-mode-map "o"               mu4e-view-open-attachment)
     (,evil-mu4e-state mu4e-view-mode-map "A"               mu4e-view-attachment-action)


### PR DESCRIPTION
h is a critical key in navigating ( `hjkl` ) and having it used to toggle HTML isn't as useful. I've swapped `h` for `H` which is a less commonly used key than `h`, so I think it should be in the default keybinding. 

This addresses https://github.com/JorisE/evil-mu4e/issues/5