### PR TITLE
Bind "g" to headers-rerun-search

### DIFF
--- a/evil-mu4e.el
+++ b/evil-mu4e.el
@@ -81,6 +81,7 @@
     (,evil-mu4e-state mu4e-headers-mode-map "J"            mu4e~headers-jump-to-maildir)
     (,evil-mu4e-state mu4e-headers-mode-map "j"            next-line)
     (,evil-mu4e-state mu4e-headers-mode-map "k"            previous-line)
+    (,evil-mu4e-state mu4e-headers-mode-map "g"            mu4e-headers-rerun-search)
     (,evil-mu4e-state mu4e-headers-mode-map ";"            mu4e-context-switch)
     (,evil-mu4e-state mu4e-headers-mode-map ,(kbd "RET")   mu4e-headers-view-message)
     (,evil-mu4e-state mu4e-headers-mode-map "/"            mu4e-headers-search-narrow)

--- a/evil-mu4e.el
+++ b/evil-mu4e.el
@@ -81,7 +81,7 @@
     (,evil-mu4e-state mu4e-headers-mode-map "J"            mu4e~headers-jump-to-maildir)
     (,evil-mu4e-state mu4e-headers-mode-map "j"            next-line)
     (,evil-mu4e-state mu4e-headers-mode-map "k"            previous-line)
-    (,evil-mu4e-state mu4e-headers-mode-map "g"            mu4e-headers-rerun-search)
+    (,evil-mu4e-state mu4e-headers-mode-map "gr"           mu4e-headers-rerun-search)
     (,evil-mu4e-state mu4e-headers-mode-map ";"            mu4e-context-switch)
     (,evil-mu4e-state mu4e-headers-mode-map ,(kbd "RET")   mu4e-headers-view-message)
     (,evil-mu4e-state mu4e-headers-mode-map "/"            mu4e-headers-search-narrow)


### PR DESCRIPTION
I think it's very useful to be able to re-run the latest search in the "headers" view, e.g. after having marked messages, etc.
Re-use the original "emacs-mode" binding.